### PR TITLE
Differentiate http mux handlers by method

### DIFF
--- a/ipStats.go
+++ b/ipStats.go
@@ -42,6 +42,7 @@ func ipsInit() {
 	srvLog.Info("ips Init")
 
 	httpSrv.RegisterHandler(
+		"GET",
 		"/debug/ipstats/",
 		ipsOnUri,
 		PRIVATE_HANDLER,

--- a/netXMux.go
+++ b/netXMux.go
@@ -316,13 +316,15 @@ func (mux *XMux) RemoveHandleFunc(method string, uriPattern string) {
 	defer mux.mu.Unlock()
 
 	key := makeKey(method, uriPattern)
-	keyNoTrailingSlash := makeKey(method, uriPattern[0:len(uriPattern)-1])
 
 	delete(mux.m, key)
 
 	n := len(uriPattern)
-	if n > 0 && uriPattern[n-1] == '/' && !mux.m[keyNoTrailingSlash].explicit {
-		delete(mux.m, keyNoTrailingSlash)
+	if n > 0 && uriPattern[n-1] == '/' {
+		keyNoTrailingSlash := makeKey(method, uriPattern[0:len(uriPattern)-1])
+		if !mux.m[keyNoTrailingSlash].explicit {
+			delete(mux.m, keyNoTrailingSlash)
+		}
 	}
 }
 

--- a/uriHandlers.go
+++ b/uriHandlers.go
@@ -88,29 +88,11 @@ func OnConfigUri(resp http.ResponseWriter, req *http.Request) {
 
 // OnUpdateConfigUri handles requests to the /debug/config uri.
 func OnUpdateConfigUri(resp http.ResponseWriter, req *http.Request) {
-	if req.Method != "POST" {
-		http.Error(
-			resp,
-			fmt.Sprintf("%d : Method not supported", http.StatusMethodNotAllowed),
-			http.StatusMethodNotAllowed,
-		)
-		return
-	}
-
 	ini.ForceUpdate()
 }
 
 // OnCrashUri handles requests to the /cmd/crash/ uri.
 func OnCrashUri(resp http.ResponseWriter, req *http.Request) {
-	if req.Method != "POST" {
-		http.Error(
-			resp,
-			fmt.Sprintf("%d : Method not supported", http.StatusMethodNotAllowed),
-			http.StatusMethodNotAllowed,
-		)
-		return
-	}
-
 	resp.Write([]byte("Crash initiated\n"))
 
 	srvLog.Info("Crash initiated via http request")
@@ -194,15 +176,6 @@ func OnPubStaticSrvUri(resp http.ResponseWriter, req *http.Request) {
 
 // OnShutdownUri handles requests on the /cmd/shutdown/ uri.
 func OnShutdownUri(resp http.ResponseWriter, req *http.Request) {
-	if req.Method != "POST" {
-		http.Error(
-			resp,
-			fmt.Sprintf("%d : Method not supported", http.StatusMethodNotAllowed),
-			http.StatusMethodNotAllowed,
-		)
-		return
-	}
-
 	resp.Write([]byte("Shutdown initiated\n"))
 
 	srvLog.Info("Shutdown initiated via http request")


### PR DESCRIPTION
Change HttpSrv.RegisterHandler to take a method argument as well making it so that the registered handler will only be invoked if that specific method is used rather than requiring the handler to detect the method by which it was called.